### PR TITLE
feat: design rulebase architecture

### DIFF
--- a/HwpxToMarkdown.vcxproj
+++ b/HwpxToMarkdown.vcxproj
@@ -136,6 +136,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\HwpxConverter.h" />
+    <ClInclude Include="include\MarkdownEngine.h" />
+    <ClInclude Include="include\MarkdownRules.h" />
     <ClInclude Include="include\OWPMLApi\OWPMLApi.h" />
     <ClInclude Include="include\OWPMLApi\OWPMLDocument.h" />
     <ClInclude Include="include\OWPMLApi\OWPMLDocumentDef.h" />
@@ -491,6 +493,7 @@
     <ClInclude Include="include\OWPML\Zip\SDZip.h" />
     <ClInclude Include="include\OWPML\Zip\unzip.h" />
     <ClInclude Include="include\OWPML\Zip\zip.h" />
+    <ClInclude Include="include\SDK_Wrapper.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include=".gitignore" />

--- a/HwpxToMarkdown.vcxproj.filters
+++ b/HwpxToMarkdown.vcxproj.filters
@@ -1042,9 +1042,6 @@
     <ClInclude Include="include\OWPMLUtil\cipher.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="include\OWPMLUtil\HncAES.h">
-      <Filter>헤더 파일</Filter>
-    </ClInclude>
     <ClInclude Include="include\OWPMLUtil\HncAlloca.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
@@ -1091,6 +1088,18 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="include\HwpxConverter.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="include\OWPMLUtil\HncAES.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="include\MarkdownEngine.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="include\SDK_Wrapper.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="include\MarkdownRules.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/HwpxConverter.h
+++ b/include/HwpxConverter.h
@@ -3,9 +3,9 @@
 // 1. Windows 및 표준 라이브러리 (SDK 내부 헤더 의존성 포함)
 #include <windows.h>
 #include <Shlwapi.h>
-#include <stack>      // 필수: Handler.h 등에서 사용
-#include <deque>      // 필수: PartNameSpaceInfo.h 등에서 사용
-#include <map>        // 필수: Document.h 등에서 사용
+#include <stack>
+#include <deque>
+#include <map>
 #include <string>
 #include <vector>
 #include <iostream>
@@ -20,29 +20,3 @@
 #include "OWPMLUtil/HncDefine.h"
 #include "OWPML/OWPML.h"
 #include "OWPML/OwpmlForDec.h"
-
-// 3. 텍스트 추출 함수 정의 (inline으로 헤더 포함 허용)
-inline void ExtractText(OWPML::CObject* pObject, std::wstring& out) {
-    if (!pObject) return;
-
-    UINT id = pObject->GetID();
-    if (id == ID_PARA_T) {
-        OWPML::CT* pText = (OWPML::CT*)pObject;
-        int count = pText->GetChildCount();
-        for (int i = 0; i < count; i++) {
-            OWPML::CObject* pChild = pText->GetObjectByIndex(i);
-            if (pChild && pChild->GetID() == ID_PARA_Char) {
-                out.append(((OWPML::CChar*)pChild)->Getval());
-            }
-        }
-    }
-    else if (id == ID_PARA_LineSeg) {
-        out += L"\n";
-    }
-    else {
-        OWPML::Objectlist* pChildList = pObject->GetObjectList();
-        if (pChildList) {
-            for (auto child : *pChildList) ExtractText(child, out);
-        }
-    }
-}

--- a/include/MarkdownEngine.h
+++ b/include/MarkdownEngine.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "MarkdownRules.h" // 2단계(Rules)를 포함하면 1단계(Wrapper)까지 자동으로 연결됨
+
+// 최종 엔진: 메인에서 이 함수를 호출하면 전체 변환이 시작됩니다.
+inline void ExtractText(OWPML::CObject* pObject, std::wstring& out) {
+    if (!pObject) return;
+
+    // [Step 1] 진입 규칙 실행 (Rules.h의 OnPreProcess)
+    // 여기서 스타일을 보고 제목(#)을 붙일지 말지 결정합니다.
+    Rules::OnPreProcess(pObject, out);
+
+    // [Step 2] 데이터 추출 실행 (Rules.h의 OnProcess)
+    // 여기서 실제 텍스트 글자들을 수집합니다.
+    Rules::OnProcess(pObject, out);
+
+    // [Step 3] 재귀 탐색 (Wrapper.h의 탐색 도구 활용)
+    // 현재 객체(부모) 밑에 자식들이 있다면 하나씩 꺼내서 다시 이 함수를 호출합니다.
+    OWPML::Objectlist* pChildList = SDK::GetChildList(pObject);
+    if (pChildList) {
+        for (auto child : *pChildList) {
+            ExtractText(child, out); // <--- 재귀가 돌아가는 핵심 지점
+        }
+    }
+
+    // [Step 4] 이탈 규칙 실행 (Rules.h의 OnPostProcess)
+    // 자식들까지 다 훑고 올라오면서 문단 끝 줄바꿈(\n\n) 등을 처리합니다.
+    Rules::OnPostProcess(pObject, out);
+}

--- a/include/MarkdownRules.h
+++ b/include/MarkdownRules.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "SDK_Wrapper.h"
+
+namespace Rules {
+
+    // 1. [진입 규칙] 객체에 처음 들어갈 때 실행 (예: 제목 기호 # 추가)
+    inline void OnPreProcess(OWPML::CObject* pObj, std::wstring& out) {
+        UINT id = SDK::GetID(pObj);
+
+        // CT(텍스트 뭉치)를 만났을 때 스타일 확인
+        if (id == ID_PARA_T) {
+            OWPML::CT* pText = (OWPML::CT*)pObj;
+            UINT styleID = SDK::GetTextStyleID(pText);
+
+            // 스타일 ID가 1~3번이면 마크다운 제목(#)으로 간주
+            if (styleID >= 2 && styleID <= 4) {
+                out += std::wstring(styleID-1, L'#') + L" ";
+            }
+        }
+    }
+
+    // 2. [데이터 규칙] 실제 글자 및 텍스트 내부의 줄바꿈 추출
+    inline void OnProcess(OWPML::CObject* pObj, std::wstring& out) {
+        UINT id = SDK::GetID(pObj);
+
+        // <hp:t> 태그를 처리할 때 그 안의 자식들을 순서대로 검사
+        if (id == ID_PARA_T) {
+            OWPML::CT* pText = (OWPML::CT*)pObj;
+            int count = SDK::GetChildCount(pText);
+
+            for (int i = 0; i < count; i++) {
+                OWPML::CObject* pChild = SDK::GetChildByIndex(pText, i);
+                if (!pChild) continue;
+
+                UINT childID = SDK::GetID(pChild);
+
+                // 자식이 일반 글자(<hp:char>)인 경우
+                if (childID == ID_PARA_Char) {
+                    out.append(SDK::GetValue((OWPML::CChar*)pChild));
+                }
+                // 자식이 줄바꿈(<hp:lineBreak/>)인 경우
+                else if (childID == ID_PARA_LineBreak) {
+                    out += L"  \n"; // 마크다운 강제 줄바꿈 (스페이스 2개 + \n)
+                }
+            }
+        }
+    }
+
+    // 3. 이탈 규칙
+    inline void OnPostProcess(OWPML::CObject* pObj, std::wstring& out) {
+        UINT id = SDK::GetID(pObj);
+
+        // 헤더에 정의된 ID_PARA_PType 사용
+        if (id == ID_PARA_PType) {
+            out += L"\n\n"; // 문단 간격 띄우기
+        }
+    }
+}

--- a/include/SDK_Wrapper.h
+++ b/include/SDK_Wrapper.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "HwpxConverter.h"
+
+namespace SDK {
+
+    // 트리 탐색 도구. 재귀 돌아갑니다.===============================
+    
+    // 현재 노드가 어떤 타입(문단, 텍스트, 그림 등)인지 식별 번호를 가져옵니다.
+    inline UINT GetID(OWPML::CObject* pObj) { return pObj->GetID(); }
+
+    // 현재 노드 밑에 달린 자식 객체들의 목록(리스트)을 가져옵니다. (재귀의 핵심)
+    inline OWPML::Objectlist* GetChildList(OWPML::CObject* pObj) { return pObj->GetObjectList(); }
+
+
+    // 텍스트 뭉치(CT) 분석 도구.  =============================
+
+    // CT(텍스트 런) 객체 안에 실제 글자(CChar)가 몇 개 들어있는지 확인합니다.
+    inline int GetChildCount(OWPML::CT* pText) {
+        return pText ? pText->GetChildCount() : 0;
+    }
+
+    // CT 객체 내부에서 n번째 자식 객체(보통 CChar)를 콕 집어서 가져옵니다.
+    inline OWPML::CObject* GetChildByIndex(OWPML::CT* pText, int index) {
+        return pText ? pText->GetObjectByIndex(index) : nullptr;
+    }
+
+    // 이 텍스트 뭉치에 적용된 스타일 번호를 가져옵니다.
+    inline UINT GetTextStyleID(OWPML::CT* pText) {
+        return pText ? pText->GetCharStyleIDRef() : 0;
+    }
+
+
+    // [실제 글자(CChar) 데이터 추출] -------------------------------------------
+
+    // CChar 객체에 담긴 실제 문자열(wstring) 값을 뽑아냅니다.
+    inline std::wstring GetCharValue(OWPML::CChar* pChar) {
+        return pChar ? pChar->Getval() : L"";
+    }
+
+    // 기존 GetValue와 중복될 수 있어 하나로 통일하거나 별칭으로 사용합니다.
+    inline std::wstring GetValue(OWPML::CChar* pChar) {
+        return GetCharValue(pChar);
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,27 +1,46 @@
-#include "HwpxConverter.h"
+#include "MarkdownEngine.h"
 
 int wmain(int argc, wchar_t* argv[]) {
-    if (argc < 3) return -1;
+    // 인자 체크: 프로그램명, 입력파일(hwpx), 출력파일(md)
+    if (argc < 3) {
+        std::wcout << L"사용법: " << argv[0] << L" <input.hwpx> <output.md>" << std::endl;
+        return -1;
+    }
 
-    // 1. 읽기
+    // 1. 문서 열기
     OWPML::COwpmlDocumnet* pDoc = OWPML::COwpmlDocumnet::OpenDocument(argv[1]);
-    if (!pDoc) return -1;
+    if (!pDoc) {
+        std::wcout << L"파일을 열 수 없습니다: " << argv[1] << std::endl;
+        return -1;
+    }
 
-    // 2. 뽑기
+    // 2. 텍스트 추출 (재귀 시작)
     std::wstring resultText;
     auto* sections = pDoc->GetSections();
     if (sections) {
-        for (auto* section : *sections) ExtractText(section, resultText);
+        for (auto* section : *sections) {
+            // 우리가 만든 Layer 2 엔진 호출
+            ExtractText(section, resultText);
+        }
     }
 
-    // 3. 저장
+    // 3. 파일 저장 (UTF-8 인코딩 설정)
     std::wofstream f(argv[2]);
+    // 마크다운 표준인 UTF-8로 한글을 저장하기 위한 설정
     f.imbue(std::locale(std::locale(), new std::codecvt_utf8_utf16<wchar_t>));
+
     if (f.is_open()) {
         f << resultText;
         f.close();
+        std::wcout << L"변환 완료: " << argv[2] << std::endl;
+    }
+    else {
+        std::wcout << L"출력 파일을 생성할 수 없습니다." << std::endl;
     }
 
+    // 4. 정리
+    // OpenDocument로 생성된 객체 해제
     delete pDoc;
+
     return 0;
 }


### PR DESCRIPTION
### 헤더파일 4개 개발
- HwpxConverter.h
- MarkdownEngine.h
- MarkdownRules.h
- SDK_Wrapper.h

+ 추후 SDK 교체를 염두해 두고 설계했음
### Layer 1 : SDK_Wrapper (추상화 계층) 
SDK의 메서드를 우리가 이해하기 쉬운 이름으로 번역

### Layer 2: Recursive_Engine (흐름 계층)
트리의 뿌리(Section)부터 잎(Char)까지 '길을 찾는 것'만 담당

### Layer 3: Markdown_Rules (판단 계층)
스타일이 1번이면 #을 추가하는 비즈니스 로직 담당.

### HwpxConverter
헤더파일 로드 순서 저장