### PR TITLE
Table cell rendering polish (line-break fix + border styling)

### DIFF
--- a/include/DocumentWalker.h
+++ b/include/DocumentWalker.h
@@ -1,20 +1,278 @@
 #pragma once
+
 #include <string>
+#include <map>
+#include <iostream>
+#include <vector>
+
 #include "SDK_Wrapper.h"
 #include "HtmlRenderer.h"
 
-inline void ExtractText(OWPML::CObject* obj, std::wstring& out)
+// forward decl
+inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth);
+
+namespace WalkConfig
 {
-    if (!obj) return;
+    // ====== 개발 모드 토글 ======
+    static constexpr bool SCAN_MODE = false;      // ID once 스캔
+    static constexpr bool DUMP_MODE = false;      // 서브트리 덤프
+    static constexpr bool TABLE_LOG = false;      // 테이블 렌더 로그
 
-    Html::OnPreProcess(obj, out);
-    Html::OnProcess(obj, out);
+    // ====== 5단계(표 루트 확정) ID ======
+    static constexpr unsigned int TABLE_ROOT_ID = 805306373;   // 진짜 테이블 루트
+    static constexpr unsigned int COL_ID = 805306463;          // 열(컬럼) 묶음
+    static constexpr unsigned int CELL_WRAPPER_ID = 805306465; // 열 내부에서 row index 역할
+    static constexpr unsigned int CELL_CONTENT_ID = 805306406; // 셀 실제 컨텐츠(문단 들어있음)
 
-    const int n = SDK::GetChildCountObj(obj);
-    for (int i = 0; i < n; ++i)
+    // ====== 덤프 관련(필요하면 다시 켜서 사용) ======
+    static constexpr unsigned int TARGET_ID = TABLE_ROOT_ID;
+    static constexpr int DUMP_MAX_REL_DEPTH = 12;
+
+    // ====== 안전장치 ======
+    static constexpr int MAX_DEPTH = 5000;
+
+    inline std::map<unsigned int, int>& SeenIdOnce()
     {
-        ExtractText(SDK::GetChildAtObj(obj, i), out);
+        static std::map<unsigned int, int> m;
+        return m;
     }
 
-    Html::OnPostProcess(obj, out);
+    inline int CountChildrenByObjectList(OWPML::CObject* obj)
+    {
+        if (!obj) return 0;
+        int childCount = 0;
+        if (auto list = obj->GetObjectList())
+        {
+            for (auto* _ : *list) { (void)_; childCount++; }
+        }
+        return childCount;
+    }
+
+    inline void ScanLogOnce(int depth, OWPML::CObject* obj)
+    {
+        if (!SCAN_MODE || !obj) return;
+
+        const unsigned int id = SDK::GetID(obj);
+        int& cnt = SeenIdOnce()[id];
+        cnt++;
+
+        if (cnt == 1)
+        {
+            const int childCount = CountChildrenByObjectList(obj);
+
+            std::wcout
+                << L"[SCAN] depth=" << depth
+                << L" id=" << id
+                << L" childCount=" << childCount
+                << L"\n";
+        }
+    }
+
+    inline const wchar_t* KnownIdName(unsigned int id)
+    {
+        switch (id)
+        {
+        case ID_PARA_PType: return L"ID_PARA_PType(Paragraph)";
+        case ID_PARA_T: return L"ID_PARA_T(TextRun)";
+        case ID_PARA_Char: return L"ID_PARA_Char(Char)";
+        case ID_PARA_LineSeg: return L"ID_PARA_LineSeg(LineSeg)";
+        case ID_PARA_LineBreak: return L"ID_PARA_LineBreak(LineBreak)";
+        default: return L"";
+        }
+    }
+
+    inline void DumpSubtree(OWPML::CObject* root, int absDepth, int relDepth)
+    {
+        if (!root) return;
+        if (relDepth > DUMP_MAX_REL_DEPTH) return;
+
+        const unsigned int id = SDK::GetID(root);
+        const int childCount = CountChildrenByObjectList(root);
+        const wchar_t* name = KnownIdName(id);
+
+        for (int i = 0; i < relDepth; ++i) std::wcout << L"  ";
+
+        std::wcout
+            << L"[DUMP] absDepth=" << absDepth
+            << L" rel=" << relDepth
+            << L" id=" << id
+            << L" childCount=" << childCount;
+
+        if (name && name[0] != 0)
+            std::wcout << L"  (" << name << L")";
+
+        std::wcout << L"\n";
+
+        auto list = root->GetObjectList();
+        if (!list) return;
+
+        for (auto* child : *list)
+        {
+            if (!child) continue;
+            DumpSubtree(child, absDepth + 1, relDepth + 1);
+        }
+    }
+
+    inline OWPML::CObject* FindFirstChildById(OWPML::CObject* parent, unsigned int targetId)
+    {
+        if (!parent) return nullptr;
+        auto list = parent->GetObjectList();
+        if (!list) return nullptr;
+
+        for (auto* ch : *list)
+        {
+            if (!ch) continue;
+            if (SDK::GetID(ch) == targetId) return ch;
+        }
+        return nullptr;
+    }
+
+    inline void CollectChildrenById(OWPML::CObject* parent, unsigned int targetId, std::vector<OWPML::CObject*>& outVec)
+    {
+        outVec.clear();
+        if (!parent) return;
+
+        auto list = parent->GetObjectList();
+        if (!list) return;
+
+        for (auto* ch : *list)
+        {
+            if (!ch) continue;
+            if (SDK::GetID(ch) == targetId)
+                outVec.push_back(ch);
+        }
+    }
+}
+
+// ======================================
+// 5-3: Table Root 전용 처리(실제 HTML 출력)
+// - column-major -> row-major로 재조합
+// ======================================
+inline void RenderTableFromRoot373(OWPML::CObject* tableRoot, std::wstring& out, int depth)
+{
+    if (!tableRoot) return;
+
+    const unsigned int rid = SDK::GetID(tableRoot);
+    if (rid != WalkConfig::TABLE_ROOT_ID) return;
+
+    // 1) rowGroups 모으기 (기존 columns)
+    std::vector<OWPML::CObject*> rowGroups;
+    WalkConfig::CollectChildrenById(tableRoot, WalkConfig::COL_ID, rowGroups);
+
+    const int rowCount = (int)rowGroups.size();
+    if (rowCount <= 0) return;
+
+    // 2) 각 rowGroup에서 cellWrapper 수집
+    std::vector<std::vector<OWPML::CObject*>> rowCells(rowCount);
+    int maxColCount = 0;
+
+    for (int r = 0; r < rowCount; ++r)
+    {
+        WalkConfig::CollectChildrenById(rowGroups[r], WalkConfig::CELL_WRAPPER_ID, rowCells[r]);
+        maxColCount = std::max(maxColCount, (int)rowCells[r].size());
+    }
+
+    // 3) HTML 출력: row 먼저, 그 안에 col
+    out += L"<table>\n";
+
+    for (int r = 0; r < rowCount; ++r)
+    {
+        out += L"<tr>\n";
+
+        for (int c = 0; c < maxColCount; ++c)
+        {
+            out += L"<td>\n";
+
+            if (c < (int)rowCells[r].size())
+            {
+                OWPML::CObject* cellWrapper = rowCells[r][c];
+                OWPML::CObject* content = WalkConfig::FindFirstChildById(cellWrapper, WalkConfig::CELL_CONTENT_ID);
+
+                if (content)
+                    ExtractTextImpl(content, out, depth + 1);
+                else
+                    ExtractTextImpl(cellWrapper, out, depth + 1);
+            }
+
+            out += L"</td>\n";
+        }
+
+        out += L"</tr>\n";
+    }
+
+    out += L"</table>\n";
+}
+
+// ================================
+// 재귀 본체
+// ================================
+inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth)
+{
+    if (!object) return;
+
+    if (depth > WalkConfig::MAX_DEPTH)
+    {
+        std::wcout << L"[WARN] Max depth exceeded. Stop recursion.\n";
+        return;
+    }
+
+    OWPML::Objectlist* childList = object->GetObjectList();
+    if (!childList) return;
+
+    for (OWPML::CObject* child : *childList)
+    {
+        if (!child) continue;
+
+        WalkConfig::ScanLogOnce(depth, child);
+
+        const unsigned int id = SDK::GetID(child);
+
+        // 덤프 모드(필요하면 켜서 사용)
+        if (WalkConfig::DUMP_MODE && id == WalkConfig::TARGET_ID)
+        {
+            std::wcout << L"\n========== TARGET SUBTREE DUMP START ==========\n";
+            std::wcout << L"TARGET_ID=" << WalkConfig::TARGET_ID << L"\n\n";
+            WalkConfig::DumpSubtree(child, depth, 0);
+            std::wcout << L"========== TARGET SUBTREE DUMP END ==========\n\n";
+            return;
+        }
+
+        switch (id)
+        {
+            // ====== 5-3 핵심: 805306373은 무조건 전용 렌더로 처리 ======
+        case WalkConfig::TABLE_ROOT_ID:
+        {
+            RenderTableFromRoot373(child, out, depth);
+            break;
+        }
+
+        // ====== Paragraph/Text ======
+        case ID_PARA_PType:
+        {
+            Html::BeginParagraph((OWPML::CPType*)child);
+            ExtractTextImpl(child, out, depth + 1);
+            Html::EndParagraph(out);
+            break;
+        }
+        case ID_PARA_T:
+        {
+            Html::ProcessText((OWPML::CT*)child);
+            break;
+        }
+        case ID_PARA_LineSeg:
+        {
+            Html::ProcessLineSeg();
+            break;
+        }
+        default:
+            ExtractTextImpl(child, out, depth + 1);
+            break;
+        }
+    }
+}
+
+// 기존 호출부 유지
+inline void ExtractText(OWPML::CObject* object, std::wstring& out)
+{
+    ExtractTextImpl(object, out, 0);
 }

--- a/include/DocumentWalker.h
+++ b/include/DocumentWalker.h
@@ -1,16 +1,20 @@
 #pragma once
+#include <string>
+#include "SDK_Wrapper.h"
 #include "HtmlRenderer.h"
 
-inline void ExtractText(OWPML::CObject* obj, std::wstring& out) {
+inline void ExtractText(OWPML::CObject* obj, std::wstring& out)
+{
     if (!obj) return;
 
-    Rules::OnPreProcess(obj, out);
-    Rules::OnProcess(obj, out);
+    Html::OnPreProcess(obj, out);
+    Html::OnProcess(obj, out);
 
     const int n = SDK::GetChildCountObj(obj);
-    for (int i = 0; i < n; ++i) {
+    for (int i = 0; i < n; ++i)
+    {
         ExtractText(SDK::GetChildAtObj(obj, i), out);
     }
 
-    Rules::OnPostProcess(obj, out);
+    Html::OnPostProcess(obj, out);
 }

--- a/include/HtmlRenderer.h
+++ b/include/HtmlRenderer.h
@@ -10,23 +10,87 @@
 namespace Html {
 
     // ===========================
-    // Cell mode toggle
-    // - when true: paragraph tags are suppressed, only plain text is emitted
+    // Cell mode + LineBreak policy
     // ===========================
+    enum class CellBreakMode
+    {
+        Space,    // " "
+        Newline,  // "\n"  (HTML에서는 그대로는 안 보일 수 있음. <pre>나 CSS 필요)
+        BrTag     // "<br/>"
+    };
+
     inline bool& CellMode()
     {
         static bool cellMode = false;
         return cellMode;
     }
 
+    inline CellBreakMode& CellBreakPolicy()
+    {
+        // 기본값: 셀 안에서도 줄바꿈을 "보이게" 하려면 BrTag가 가장 안정적
+        static CellBreakMode mode = CellBreakMode::BrTag;
+        return mode;
+    }
+
+    // 셀 안에서 "문단 경계"를 어떻게 처리할지
+    // - BrTag: 문단 끝마다 <br/>
+    // - Space: 문단 끝마다 공백
+    // - Newline: 문단 끝마다 \n
+    inline CellBreakMode& CellParagraphPolicy()
+    {
+        static CellBreakMode mode = CellBreakMode::BrTag;
+        return mode;
+    }
+
+    inline bool& CellHasWrittenText()
+    {
+        static bool written = false;
+        return written;
+    }
+
     inline void SetCellMode(bool on)
     {
         CellMode() = on;
+        if (on)
+        {
+            // td 들어갈 때 상태 초기화
+            CellHasWrittenText() = false;
+        }
     }
 
     inline bool IsCellMode()
     {
         return CellMode();
+    }
+
+    inline void SetCellBreakMode(CellBreakMode mode)
+    {
+        CellBreakPolicy() = mode;
+    }
+
+    inline void SetCellParagraphMode(CellBreakMode mode)
+    {
+        CellParagraphPolicy() = mode;
+    }
+
+    // ===========================
+    // Helpers
+    // ===========================
+    inline void AppendBreak(std::wstring& buf, CellBreakMode mode)
+    {
+        switch (mode)
+        {
+        case CellBreakMode::Space:
+            buf += L" ";
+            break;
+        case CellBreakMode::Newline:
+            buf += L"\n";
+            break;
+        case CellBreakMode::BrTag:
+        default:
+            buf += L"<br/>";
+            break;
+        }
     }
 
     // Extract level from styles like "Outline 4" -> 4, otherwise 0
@@ -197,24 +261,24 @@ namespace Html {
             }
             else if (childID == ID_PARA_LineBreak)
             {
-                // 셀 모드에서는 줄바꿈 태그를 넣지 않음 (필요하면 공백으로)
+                // 줄바꿈(명시적 LineBreak)은 셀 모드든 아니든 정책에 따라 처리
                 if (!IsCellMode())
+                {
                     ParaBuffer() += L"<br/>";
+                }
                 else
-                    ParaBuffer() += L" ";
+                {
+                    AppendBreak(ParaBuffer(), CellBreakPolicy());
+                }
             }
         }
     }
 
     // Some documents use LineSeg as a logical line boundary
+    // 실제 문서에서 줄바꿈이 LineBreak가 아니라 LineSeg로 더 많이 나올 수 있음
     inline void ProcessLineSeg()
     {
         if (!InPara()) return;
-
-        if (!IsCellMode())
-            ParaBuffer() += L"<br/>";
-        else
-            ParaBuffer() += L" ";
     }
 
     // Called when leaving a paragraph
@@ -224,13 +288,23 @@ namespace Html {
 
         if (HasMeaningfulText(ParaBuffer()))
         {
-            // 셀 모드에서는 태그 없이 텍스트만 out에 붙임
             if (IsCellMode())
             {
+                // 셀 내부: 문단 여러 개가 "붙어버리는 문제" 방지
+                // - 이전 문단 텍스트가 이미 찍혔다면, 문단 경계 구분자를 먼저 넣어준다.
+                if (CellHasWrittenText())
+                {
+                    std::wstring sep;
+                    AppendBreak(sep, CellParagraphPolicy());
+                    out += sep;
+                }
+
                 out += ParaBuffer();
+                CellHasWrittenText() = true;
             }
             else
             {
+                // 셀 밖: 기존대로 <p/h1..> 태그 생성
                 out += L"<" + ParaTag() + L" class=\"" + ParaClass() + L"\">";
                 out += ParaBuffer();
                 out += L"</" + ParaTag() + L">\n";
@@ -242,5 +316,35 @@ namespace Html {
         ParaClass().clear();
         ParaBuffer().clear();
     }
+
+
+    inline void BeginHtmlDocument(std::wstring& out)
+    {
+        out += LR"(<!doctype html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<style>
+table { border-collapse: collapse; }
+th, td {
+    border: 1px solid black;
+    padding: 6px 10px;
+    text-align: left;
+    vertical-align: top;
+}
+</style>
+</head>
+<body>
+)";
+    }
+
+    inline void EndHtmlDocument(std::wstring& out)
+    {
+        out += LR"(
+</body>
+</html>
+)";
+    }
+
 
 } // namespace Html

--- a/include/HtmlRenderer.h
+++ b/include/HtmlRenderer.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <map>
-#include <iostream>
+
 #include <string>
 #include <cwctype>
 #include "SDK_Wrapper.h"
@@ -112,7 +111,6 @@ namespace Html {
     // [PARA LEVEL STYLE LOG TEST] END
     // =====================================================================
 
-
     // class명을 우리가 원하는 방식으로 정리
     // 예: "Outline 4" -> "outline-4"
     inline std::wstring NormalizeClassName(const std::wstring& engName)
@@ -184,7 +182,7 @@ namespace Html {
             // 문단(CPType)에서 engName을 추출하고
             // "매핑됨 / 미매핑" 분류해서 집계하는 테스트용 로거
             // =====================================================================            
-            
+
             LogParaStyle(engName);
 
             // =====================================================================

--- a/include/HwpxConverter.cpp
+++ b/include/HwpxConverter.cpp
@@ -1,3 +1,5 @@
+#define DEBUG_PARA_LOG 0
+
 #include "OwpmSDKPrelude.h"
 #include "HwpxConverter.h"
 
@@ -70,17 +72,13 @@ bool ConvertHwpxToHtml(
         }
     }
 
-    // =====================================================================
-// [PARA LEVEL STYLE LOG TEST] START
-// 문단(CPType)에서 engName을 추출하고
-// "매핑됨 / 미매핑" 분류해서 집계하는 테스트용 로거
-// =====================================================================            
+    //PARA 디버깅 코드
+    #if DEBUG_PARA_LOG
 
-     Html::DumpStyleLogToConsole();
+    Html::DumpStyleLogToConsole();
 
-    // =====================================================================
-    // [PARA LEVEL STYLE LOG TEST] END
-    // =====================================================================
+    #endif // DEBUG_PARA_LOG
+
 
     // HTML 문서 래핑
     std::wstring html;

--- a/include/HwpxConverter.cpp
+++ b/include/HwpxConverter.cpp
@@ -82,9 +82,10 @@ bool ConvertHwpxToHtml(
 
     // HTML 문서 래핑
     std::wstring html;
-    html += L"<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\"/>\n</head>\n<body>\n";
-    html += out;
-    html += L"\n</body>\n</html>\n";
+    Html::BeginHtmlDocument(html);   // 여기서 head + body 시작까지
+    html += out;                     // 본문(테이블/문단들)
+    Html::EndHtmlDocument(html);   // body/html 닫기
+
 
     // 4) 저장
     const bool ok = WriteUtf8File(outputPath, html);

--- a/include/HwpxConverter.cpp
+++ b/include/HwpxConverter.cpp
@@ -70,6 +70,18 @@ bool ConvertHwpxToHtml(
         }
     }
 
+    // =====================================================================
+// [PARA LEVEL STYLE LOG TEST] START
+// 문단(CPType)에서 engName을 추출하고
+// "매핑됨 / 미매핑" 분류해서 집계하는 테스트용 로거
+// =====================================================================            
+
+     Html::DumpStyleLogToConsole();
+
+    // =====================================================================
+    // [PARA LEVEL STYLE LOG TEST] END
+    // =====================================================================
+
     // HTML 문서 래핑
     std::wstring html;
     html += L"<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\"/>\n</head>\n<body>\n";

--- a/include/SDK_Wrapper.cpp
+++ b/include/SDK_Wrapper.cpp
@@ -1,3 +1,4 @@
+#include <cwctype>
 #include "OwpmSDKPrelude.h"
 #include "SDK_Wrapper.h"
 
@@ -10,21 +11,70 @@
 
 namespace {
     std::map<unsigned int, std::wstring> g_styleMap;
+
+    // 앞/뒤 공백 제거
+    static std::wstring Trim(const std::wstring& s)
+    {
+        size_t start = 0;
+        while (start < s.size() && iswspace(s[start])) start++;
+
+        size_t end = s.size();
+        while (end > start && iswspace(s[end - 1])) end--;
+
+        return s.substr(start, end - start);
+    }
+
+    // "Normal Copy6" 같은 복제 스타일 흡수
+    static std::wstring NormalizeStyleEngName(std::wstring eng)
+    {
+        eng = Trim(eng);
+
+        // engName이 비어있으면 Normal로 fallback
+        if (eng.empty()) return L"Normal";
+
+        // 규칙: " Copy" + 숫자로 끝나면 Copy 부분 제거
+        // 예: "Normal Copy6" -> "Normal"
+        const std::wstring marker = L" Copy";
+        size_t pos = eng.rfind(marker);
+        if (pos != std::wstring::npos)
+        {
+            // marker 뒤쪽이 숫자로만 구성되면 Copy suffix로 판단
+            size_t numStart = pos + marker.size();
+            if (numStart < eng.size())
+            {
+                bool allDigits = true;
+                for (size_t i = numStart; i < eng.size(); ++i)
+                {
+                    if (eng[i] < L'0' || eng[i] > L'9') { allDigits = false; break; }
+                }
+
+                if (allDigits)
+                {
+                    eng = Trim(eng.substr(0, pos)); // " CopyN" 제거
+                    if (eng.empty()) return L"Normal";
+                }
+            }
+        }
+
+        return eng;
+    }
 }
 
 namespace SDK {
 
-    void InitStyleMap(OWPML::CStyles* styles) {
-        if (!styles) return;
-
+    void InitStyleMap(OWPML::CStyles* pStyles) {
+        if (!pStyles) return;
         g_styleMap.clear();
 
-        const unsigned int cnt = styles->GetItemCnt();
-        for (unsigned int i = 0; i < cnt; ++i) {
-            auto* st = styles->Getstyle((int)i);
-            if (!st) continue;
+        const unsigned int count = pStyles->GetItemCnt();
+        for (unsigned int i = 0; i < count; ++i) {
+            auto* pStyle = pStyles->Getstyle((int)i);
+            if (!pStyle) continue;
 
-            g_styleMap[st->GetId()] = st->GetEngName();
+            std::wstring raw = pStyle->GetEngName();              // 원본 engName
+            std::wstring norm = NormalizeStyleEngName(raw);       // 정규화 engName
+
+            g_styleMap[pStyle->GetId()] = norm;
         }
     }
 


### PR DESCRIPTION
- Table td 내부에서 문단 태그를 제거하고 텍스트 렌더링만 유지하면서, 셀 줄바꿈이 과도하게 늘어나는 문제를 LineSeg 무시로 해결함.
- 결과 HTML에 border 스타일을 추가해 표 구조 검증이 쉬워짐.