### PR TITLE
[#12] feat: support rowspan/colspan with cellAddr-based grid rendering

### DIFF
--- a/HwpxToMarkdown.vcxproj
+++ b/HwpxToMarkdown.vcxproj
@@ -76,6 +76,8 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -94,6 +96,7 @@
       <TreatWChar_tAsBuiltInType>false</TreatWChar_tAsBuiltInType>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <CompileAs>CompileAsCpp</CompileAs>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/include/DocumentWalker.h
+++ b/include/DocumentWalker.h
@@ -1,3 +1,14 @@
+// DocumentWalker.h (UPDATED)
+// - span 적용 + covered 스킵 + (필요시) empty 셀 표시
+// - 점유표(occupancy grid)는 "테이블 루트 단위 로컬"로만 유지 (중첩표 안전)
+// - CellMode 저장/복원 포함
+//
+// NOTE:
+// 1) 기존 maxColCount 기반 렌더링은 cellAddr 기반 그리드 렌더링으로 교체됨
+// 2) covered(병합 덮임) 칸은 td를 생성하지 않음(정석)
+// 3) 빈칸 셀은 SDK가 wrapper를 내려주는 편이라(네 로그 기준) 대부분 그대로 <td></td>로 처리됨
+//    다만 혹시 wrapper 자체가 없는 "진짜 empty hole"이 있으면 <td data-hwpx-empty="1"></td>로 보정함.
+
 #pragma once
 
 #include <string>
@@ -8,6 +19,10 @@
 
 #include "SDK_Wrapper.h"
 #include "HtmlRenderer.h"
+
+#include "OWPML/Class/Para/tc.h"
+#include "OWPML/Class/Para/cellSpan.h"
+#include "OWPML/Class/Para/cellAddr.h"
 
 // forward decl
 inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth);
@@ -22,15 +37,26 @@ namespace WalkConfig
     static constexpr bool DUMP_MODE = false;
     static constexpr bool TABLE_LOG = false;
 
-    // ====== 표 ID (너 로그로 확정된 값들) ======
-    static constexpr unsigned int TABLE_ROOT_ID = 805306373; // 테이블 루트
-    static constexpr unsigned int ROW_GROUP_ID = 805306463; // row group (small_table 기준)
-    static constexpr unsigned int CELL_WRAPPER_ID = 805306465; // 셀 wrapper
-    static constexpr unsigned int CELL_CONTENT_ID = 805306406; // 셀 내용
+    // ====== Dump 옵션 ======
+    static constexpr bool DUMP_TABLE_SUBTREE = true;
+    static constexpr bool DUMP_CELL_WRAPPER_CHILDREN = true;
 
-    // ====== 덤프 모드(필요하면 다시 켜서 사용) ======
-    static constexpr unsigned int TARGET_ID = TABLE_ROOT_ID;
-    static constexpr int DUMP_MAX_REL_DEPTH = 12;
+    // (선택) 특정 ID 서브트리 덤프하고 싶으면 사용
+    static constexpr bool DUMP_TARGET_SUBTREE = false;
+    static constexpr unsigned int TARGET_ID = 0;
+
+    // ====== 표 ID (네 로그로 확정된 값들) ======
+    static constexpr unsigned int TABLE_ROOT_ID = 805306373;     // table root
+    static constexpr unsigned int ROW_GROUP_ID = 805306463;      // row group
+    static constexpr unsigned int CELL_WRAPPER_ID = 805306465;   // cell wrapper
+    static constexpr unsigned int CELL_CONTENT_ID = 805306406;   // cell content
+    static constexpr unsigned int CELL_SPAN_ID = 805306467;      // cellSpan
+    static constexpr unsigned int CELL_ADDR_ID = 805306466;      // cellAddr
+    static constexpr unsigned int CELL_SZ_ID = 805306468;        // cellSz
+    static constexpr unsigned int CELL_MARGIN_ID = 805306469;    // cellMargin
+
+    // ====== dump depth 제한 ======
+    static constexpr int DUMP_MAX_REL_DEPTH = 20;
 
     // ====== 안전장치 ======
     static constexpr int MAX_DEPTH = 5000;
@@ -75,12 +101,12 @@ namespace WalkConfig
     {
         switch (id)
         {
-        case ID_PARA_PType: return L"ID_PARA_PType(Paragraph)";
-        case ID_PARA_T: return L"ID_PARA_T(TextRun)";
-        case ID_PARA_Char: return L"ID_PARA_Char(Char)";
-        case ID_PARA_LineSeg: return L"ID_PARA_LineSeg(LineSeg)";
-        case ID_PARA_LineBreak: return L"ID_PARA_LineBreak(LineBreak)";
-        default: return L"";
+        case ID_PARA_PType:      return L"ID_PARA_PType(Paragraph)";
+        case ID_PARA_T:          return L"ID_PARA_T(TextRun)";
+        case ID_PARA_Char:       return L"ID_PARA_Char(Char)";
+        case ID_PARA_LineSeg:    return L"ID_PARA_LineSeg(LineSeg)";
+        case ID_PARA_LineBreak:  return L"ID_PARA_LineBreak(LineBreak)";
+        default:                 return L"";
         }
     }
 
@@ -145,12 +171,139 @@ namespace WalkConfig
                 outVec.push_back(ch);
         }
     }
+
+    // ===========================
+    // cellWrapper 내부 child ID dump + addr/span 확정 로그
+    // ===========================
+    inline void DumpCellWrapperChildren(OWPML::CObject* cellWrapper, int r, int c, int depth)
+    {
+        if (!DUMP_MODE || !DUMP_CELL_WRAPPER_CHILDREN) return;
+        if (!cellWrapper) return;
+
+        auto list = cellWrapper->GetObjectList();
+        if (!list)
+        {
+            std::wcout << L"[CELL_WRAPPER] r=" << r << L" c=" << c << L" (no child list)\n";
+            return;
+        }
+
+        const unsigned int wid = SDK::GetID(cellWrapper);
+        const int childCount = CountChildrenByObjectList(cellWrapper);
+
+        std::wcout
+            << L"\n[CELL_WRAPPER] depth=" << depth
+            << L" r=" << r
+            << L" c=" << c
+            << L" wrapperId=" << wid
+            << L" childCount=" << childCount
+            << L"\n";
+
+        int idx = 0;
+        for (auto* ch : *list)
+        {
+            if (!ch) continue;
+
+            const unsigned int cid = SDK::GetID(ch);
+
+            std::wcout
+                << L"  - idx=" << idx++
+                << L" id=" << cid;
+
+            if (cid == CELL_CONTENT_ID)  std::wcout << L" (cellContent)";
+            if (cid == CELL_ADDR_ID)     std::wcout << L" (cellAddr)";
+            if (cid == CELL_SPAN_ID)     std::wcout << L" (cellSpan)";
+            if (cid == CELL_SZ_ID)       std::wcout << L" (cellSz)";
+            if (cid == CELL_MARGIN_ID)   std::wcout << L" (cellMargin)";
+
+            std::wcout << L"\n";
+
+            if (cid == CELL_ADDR_ID)
+            {
+                auto* addr = static_cast<OWPML::CCellAddr*>(ch);
+                std::wcout
+                    << L"    -> CCellAddr CONFIRMED! row="
+                    << addr->GetRowAddr()
+                    << L", col="
+                    << addr->GetColAddr()
+                    << L"\n";
+            }
+
+            if (cid == CELL_SPAN_ID)
+            {
+                auto* span = static_cast<OWPML::CCellSpan*>(ch);
+                std::wcout
+                    << L"    -> CCellSpan CONFIRMED! colSpan="
+                    << span->GetColSpan()
+                    << L", rowSpan="
+                    << span->GetRowSpan()
+                    << L"\n";
+            }
+        }
+
+        std::wcout << L"[CELL_WRAPPER] END\n";
+        std::wcout.flush();
+    }
 }
 
 // =====================
-// Table renderer
-// - small_table 기준: TABLE_ROOT(373) -> ROW_GROUP(463) -> CELL_WRAPPER(465) -> CELL_CONTENT(406)
-// - td 안은 CellMode=true 로 ExtractTextImpl을 태워서 "텍스트만" 나오게 함
+// Helpers for table rendering
+// =====================
+struct CellPos
+{
+    int r = 0;
+    int c = 0;
+
+    bool operator<(const CellPos& o) const
+    {
+        if (r != o.r) return r < o.r;
+        return c < o.c;
+    }
+};
+
+struct CellInfo
+{
+    OWPML::CObject* wrapper = nullptr;
+    OWPML::CObject* content = nullptr;
+    int rowSpan = 1;
+    int colSpan = 1;
+};
+
+inline bool IsHtmlEffectivelyEmpty(const std::wstring& html)
+{
+    // "<br/>" 같은 태그만 있는 경우를 empty로 보려는 목적
+    std::wstring s;
+    s.reserve(html.size());
+
+    // 태그 제거는 과하니, 최소한의 관용 처리:
+    // - 공백/개행 제거
+    // - "<br/>" 텍스트 제거 후 남는 게 있는지 확인
+    for (size_t i = 0; i < html.size(); ++i)
+    {
+        wchar_t ch = html[i];
+        if (ch == L' ' || ch == L'\t' || ch == L'\r' || ch == L'\n')
+            continue;
+        s.push_back(ch);
+    }
+
+    // "<br/>" 제거(여러 번)
+    const std::wstring br = L"<br/>";
+    size_t pos = 0;
+    while ((pos = s.find(br, pos)) != std::wstring::npos)
+    {
+        s.erase(pos, br.size());
+    }
+
+    // 남은 문자가 있으면 empty 아님
+    return s.empty();
+}
+
+// =====================
+// Table renderer (NEW)
+// - TABLE_ROOT(373) -> ROW_GROUP(463) -> CELL_WRAPPER(465)
+// - cellAddr 기반으로 (row,col)에 anchor 배치
+// - cellSpan 기반으로 occupied 마킹
+// - covered는 td 스킵
+// - wrapper가 없는 비covered 칸만 예외적으로 empty td 생성
 // =====================
 inline void RenderTableFromRoot373(OWPML::CObject* tableRoot, std::wstring& out, int depth)
 {
@@ -159,71 +312,203 @@ inline void RenderTableFromRoot373(OWPML::CObject* tableRoot, std::wstring& out,
     const unsigned int rid = SDK::GetID(tableRoot);
     if (rid != WalkConfig::TABLE_ROOT_ID) return;
 
+    // (중첩표 안전) CellMode 저장/복원
+    const bool prevCellMode = Html::IsCellMode();
+
+    // 0) 덤프: 표 전체 subtree
+    if (WalkConfig::DUMP_MODE && WalkConfig::DUMP_TABLE_SUBTREE)
+    {
+        std::wcout << L"\n========== TABLE SUBTREE DUMP START ==========\n";
+        std::wcout << L"TABLE_ROOT_ID=" << WalkConfig::TABLE_ROOT_ID << L"\n\n";
+        WalkConfig::DumpSubtree(tableRoot, depth, 0);
+        std::wcout << L"========== TABLE SUBTREE DUMP END ==========\n\n";
+    }
+
     // 1) rowGroups 모으기
     std::vector<OWPML::CObject*> rowGroups;
     WalkConfig::CollectChildrenById(tableRoot, WalkConfig::ROW_GROUP_ID, rowGroups);
-
-    const int rowCount = (int)rowGroups.size();
-    if (rowCount <= 0) return;
-
-    // 2) 각 rowGroup에서 cellWrapper 수집
-    std::vector<std::vector<OWPML::CObject*>> rowCells(rowCount);
-    int maxColCount = 0;
-
-    for (int r = 0; r < rowCount; ++r)
+    if (rowGroups.empty())
     {
-        WalkConfig::CollectChildrenById(rowGroups[r], WalkConfig::CELL_WRAPPER_ID, rowCells[r]);
-        maxColCount = std::max(maxColCount, (int)rowCells[r].size());
+        Html::SetCellMode(prevCellMode);
+        return;
     }
+
+    // 2) cellWrapper 수집 + (row,col) 맵 구성
+    std::map<CellPos, CellInfo> cellMap;
+
+    int inferredRowCount = 0;
+    int inferredColCount = 0;
+
+    for (size_t rg = 0; rg < rowGroups.size(); ++rg)
+    {
+        std::vector<OWPML::CObject*> wrappers;
+        WalkConfig::CollectChildrenById(rowGroups[rg], WalkConfig::CELL_WRAPPER_ID, wrappers);
+
+        for (auto* cellWrapper : wrappers)
+        {
+            if (!cellWrapper) continue;
+
+            // addr 필수 (없으면 이 방식으로 표 렌더가 어려움)
+            auto* addrObj = WalkConfig::FindFirstChildById(cellWrapper, WalkConfig::CELL_ADDR_ID);
+            if (!addrObj) continue;
+
+            auto* addr = static_cast<OWPML::CCellAddr*>(addrObj);
+            const int r = (int)addr->GetRowAddr();
+            const int c = (int)addr->GetColAddr();
+
+            // span
+            int colSpan = 1;
+            int rowSpan = 1;
+            if (auto* spanObj = WalkConfig::FindFirstChildById(cellWrapper, WalkConfig::CELL_SPAN_ID))
+            {
+                auto* span = static_cast<OWPML::CCellSpan*>(spanObj);
+                colSpan = (int)span->GetColSpan();
+                rowSpan = (int)span->GetRowSpan();
+                if (colSpan <= 0) colSpan = 1;
+                if (rowSpan <= 0) rowSpan = 1;
+            }
+
+            // content
+            auto* content = WalkConfig::FindFirstChildById(cellWrapper, WalkConfig::CELL_CONTENT_ID);
+
+            // 디버그: cellWrapper child dump
+            WalkConfig::DumpCellWrapperChildren(cellWrapper, r, c, depth);
+
+            // map 저장
+            CellPos pos{ r, c };
+            CellInfo info;
+            info.wrapper = cellWrapper;
+            info.content = content;
+            info.colSpan = colSpan;
+            info.rowSpan = rowSpan;
+
+            cellMap[pos] = info;
+
+            inferredRowCount = std::max(inferredRowCount, r + rowSpan);
+            inferredColCount = std::max(inferredColCount, c + colSpan);
+        }
+    }
+
+    if (cellMap.empty())
+    {
+        Html::SetCellMode(prevCellMode);
+        return;
+    }
+
+    // 3) rowCount / colCount 확정
+    // rowGroups.size()는 "행 그룹 개수" 기준(대부분 실제 행 수와 동일)
+    // addr 기반 inferredRowCount가 더 크면 그걸 우선 반영
+    const int rowCount = std::max((int)rowGroups.size(), inferredRowCount);
+    const int colCount = std::max(1, inferredColCount);
 
     if (WalkConfig::TABLE_LOG)
     {
-        std::wcout << L"\n[TABLE] ===== Render Start =====\n";
+        std::wcout << L"\n[TABLE] ===== Render Start (GRID) =====\n";
         std::wcout << L"[TABLE] depth=" << depth
-            << L" rows=" << rowCount
-            << L" maxCols=" << maxColCount
+            << L" rowGroups=" << (int)rowGroups.size()
+            << L" inferredRows=" << inferredRowCount
+            << L" inferredCols=" << inferredColCount
+            << L" => rows=" << rowCount
+            << L" cols=" << colCount
             << L"\n";
-        for (int r = 0; r < rowCount; ++r)
-        {
-            std::wcout << L"[TABLE]  row[" << r << L"] cols=" << (int)rowCells[r].size() << L"\n";
-        }
-        std::wcout << L"[TABLE] ==========================\n\n";
+        std::wcout << L"[TABLE] ================================\n\n";
     }
 
-    // 3) HTML 출력
+    // 4) occupancy grid (테이블 루트 로컬)
+    std::vector<std::vector<bool>> occupied(rowCount, std::vector<bool>(colCount, false));
+
+    // 5) HTML 출력
     out += L"<table>\n";
 
     for (int r = 0; r < rowCount; ++r)
     {
         out += L"<tr>\n";
 
-        for (int c = 0; c < maxColCount; ++c)
+        for (int c = 0; c < colCount; ++c)
         {
-            out += L"<td>";
-
-            // 빈셀 방어
-            if (c < (int)rowCells[r].size())
+            // covered 스킵
+            if (occupied[r][c])
             {
-                OWPML::CObject* cellWrapper = rowCells[r][c];
-                OWPML::CObject* content = WalkConfig::FindFirstChildById(cellWrapper, WalkConfig::CELL_CONTENT_ID);
-
-                Html::SetCellMode(true);
-
-                if (content)
-                    ExtractTextImpl(content, out, depth + 1);
-                else
-                    ExtractTextImpl(cellWrapper, out, depth + 1);
-
-                Html::SetCellMode(false);
+                continue;
             }
 
-            out += L"</td>\n";
+            const CellPos pos{ r, c };
+            auto it = cellMap.find(pos);
+
+            if (it != cellMap.end())
+            {
+                const CellInfo& cell = it->second;
+
+                // span attribute 구성
+                std::wstring tdOpen = L"<td";
+                if (cell.colSpan > 1)
+                {
+                    tdOpen += L" colspan=\"";
+                    tdOpen += std::to_wstring(cell.colSpan);
+                    tdOpen += L"\"";
+                }
+                if (cell.rowSpan > 1)
+                {
+                    tdOpen += L" rowspan=\"";
+                    tdOpen += std::to_wstring(cell.rowSpan);
+                    tdOpen += L"\"";
+                }
+
+                // span 점유 마킹 (anchor 포함해서 전부 true)
+                for (int rr = r; rr < r + cell.rowSpan && rr < rowCount; ++rr)
+                {
+                    for (int cc = c; cc < c + cell.colSpan && cc < colCount; ++cc)
+                    {
+                        occupied[rr][cc] = true;
+                    }
+                }
+
+                // 셀 내용은 temp에 뽑아서 "진짜 빈칸인지" 판정 후 attribute 추가 가능
+                std::wstring cellBuf;
+                cellBuf.reserve(256);
+
+                // td 내부 렌더링 모드
+                Html::SetCellMode(true);
+
+                if (cell.content)
+                    ExtractTextImpl(cell.content, cellBuf, depth + 1);
+                else if (cell.wrapper)
+                    ExtractTextImpl(cell.wrapper, cellBuf, depth + 1);
+
+                Html::SetCellMode(false);
+
+                // SDK 기준 빈칸 셀은 wrapper는 존재하고 텍스트만 없는 케이스가 많음
+                // 그때를 명시하고 싶으면 data-hwpx-empty 부여
+                const bool isEmpty = IsHtmlEffectivelyEmpty(cellBuf);
+
+                if (isEmpty)
+                {
+                    tdOpen += L" data-hwpx-empty=\"1\"";
+                }
+
+                tdOpen += L">";
+                out += tdOpen;
+
+                // 실제 내용
+                out += cellBuf;
+
+                out += L"</td>\n";
+            }
+            else
+            {
+                // occupied도 아니고 wrapper도 없으면 "비정상 hole" 또는 SDK 생략 케이스
+                // 구조 유지용으로 빈 td를 생성하되, 명시적으로 표시
+                out += L"<td data-hwpx-empty=\"1\"></td>\n";
+            }
         }
 
         out += L"</tr>\n";
     }
 
     out += L"</table>\n";
+
+    // (중첩표 안전) CellMode 복원
+    Html::SetCellMode(prevCellMode);
 }
 
 // =====================
@@ -250,8 +535,8 @@ inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth
 
         const unsigned int id = SDK::GetID(child);
 
-        // 덤프 모드(필요하면 켜서 사용)
-        if (WalkConfig::DUMP_MODE && id == WalkConfig::TARGET_ID)
+        // (선택) TARGET 서브트리 덤프
+        if (WalkConfig::DUMP_MODE && WalkConfig::DUMP_TARGET_SUBTREE && id == WalkConfig::TARGET_ID)
         {
             std::wcout << L"\n========== TARGET SUBTREE DUMP START ==========\n";
             std::wcout << L"TARGET_ID=" << WalkConfig::TARGET_ID << L"\n\n";
@@ -262,14 +547,14 @@ inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth
 
         switch (id)
         {
-            // TABLE ROOT는 전용 렌더로만 처리하고, 절대 재귀로 내려가지 않음
+            // TABLE ROOT는 전용 렌더러로 처리
         case WalkConfig::TABLE_ROOT_ID:
         {
             RenderTableFromRoot373(child, out, depth);
             break;
         }
 
-        // 일반 Paragraph 출력 (표 밖 텍스트)
+        // Paragraph (표 밖 텍스트)
         case ID_PARA_PType:
         {
             Html::BeginParagraph((OWPML::CPType*)child);
@@ -285,7 +570,7 @@ inline void ExtractTextImpl(OWPML::CObject* object, std::wstring& out, int depth
             break;
         }
 
-        // 줄바꿈 처리 (표 밖에서만 의미 있음)
+        // 줄바꿈 세그먼트
         case ID_PARA_LineSeg:
         {
             Html::ProcessLineSeg();


### PR DESCRIPTION
### 변경 내용

* HWPX 표 렌더링 시 cellSpan(colSpan/rowSpan)을 HTML `colspan/rowspan`으로 반영하도록 개선했습니다.
* `cellAddr(row, col)` 기반으로 셀을 좌표 매핑하여 테이블을 그리드 방식으로 렌더링합니다.
* 병합으로 덮인 셀(covered cell)은 `<td>`를 생성하지 않고 스킵하도록 처리했습니다.
* 중첩 표(nested table) 케이스를 고려하여 테이블 렌더링 상태(CellMode)를 저장/복원하도록 보강했습니다.
* 디버그를 위해 테이블 subtree dump 및 cellWrapper child 구조 출력 로그를 추가했습니다.

### 기대 효과

* 가로/세로 병합된 표가 기존보다 정확하게 HTML로 변환됩니다.
* 병합으로 인해 누락되는 셀 좌표가 자연스럽게 유지되어 표 레이아웃이 깨지지 않습니다.
* 중첩 표가 포함된 문서에서도 표 렌더링이 안정적으로 동작합니다.

### 테스트

* colSpan(가로 병합) 케이스 정상 반영 확인
* rowSpan(세로 병합) 케이스 정상 반영 확인
* 병합 덮임 셀의 `<td>` 미생성(covered skip) 동작 확인
* 일부 셀 내용이 빈 표(빈칸 셀 포함)에서도 레이아웃 유지 확인
* 중첩 표 문서에서 재귀 렌더링 시 상태 누수 없이 동작 확인

### 참고

* 현재 구현은 테이블 단위로 로컬 점유표(occupancy grid)를 생성하여 병합 상태를 관리합니다.
* 빈 셀의 경우 SDK가 wrapper를 제공하는 케이스가 많아 대부분 그대로 `<td></td>` 형태로 출력됩니다.
  (예외적으로 wrapper 자체가 없는 hole은 구조 유지를 위해 empty cell로 생성)

### 결과 예시

병합(colSpan/rowSpan) 및 빈칸 셀 포함 표 변환 결과 스크린샷을 첨부했습니다.
경찰청 공식 발간 자료를 테스트 자료로 사용했습니다.

<img width="966" height="466" alt="image" src="https://github.com/user-attachments/assets/1a0cf963-2174-4e87-9589-ff94181a9b4a" />

<img width="1042" height="369" alt="image" src="https://github.com/user-attachments/assets/1c71b944-2f56-4903-8821-98c414d3c1cc" />
