### PR TITLE
[#15] refactor : move all OWPML headers to OwpmSDKPrelude to prevent …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,4 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 /lib
 /HwpxToMarkdown
 /Release
-/include/OWPML
-/include/OWPMLApi
-/include/OWPMLUtil
+/include
 
 ### C ###
 # Prerequisites

--- a/src/app/HwpxConverter.cpp
+++ b/src/app/HwpxConverter.cpp
@@ -7,10 +7,6 @@
 #include "walker/DocumentWalker.h"
 #include "sdk/SDK_Wrapper.h"
 
-// 스타일 접근용
-#include "OWPML/Class/Head/HWPMLHeadType.h"
-#include "OWPML/Class/Head/MappingTableType.h"
-#include "OWPML/Class/Head/styles.h"
 
 static bool WriteUtf8File(const std::wstring& path, const std::wstring& content) {
     // wchar -> utf8

--- a/src/render/HtmlRenderer.cpp
+++ b/src/render/HtmlRenderer.cpp
@@ -4,8 +4,8 @@
 #include <map>
 #include <iostream>
 
-#include "sdk/OwpmSDKPrelude.h"
 #include "sdk/SDK_Wrapper.h"
+#include "sdk/OwpmSDKPrelude.h"
 
 namespace Html {
 

--- a/src/sdk/OwpmSDKPrelude.h
+++ b/src/sdk/OwpmSDKPrelude.h
@@ -41,3 +41,21 @@
 #include "OWPMLUtil/HncDefine.h"
 #include "OWPML/OWPML.h"
 #include "OWPML/OwpmlForDec.h"
+
+// ===== 4) 한컴 SDK - Head/Styles 쪽 타입 보강 (HwpxConverter.cpp에서 빼낸 것들) =====
+#include "OWPML/Class/Head/HWPMLHeadType.h"
+#include "OWPML/Class/Head/MappingTableType.h"
+#include "OWPML/Class/Head/styles.h"
+
+// 세부 클래스 헤더 (스타일 파싱용)
+#include "OWPML/Class/Head/StyleType.h"
+#include "OWPML/Class/Para/PType.h"
+#include "OWPML/Class/Para/t.h"
+#include "OWPML/Class/Para/text.h"
+
+#include "OWPML/Class/Para/cellAddr.h"
+#include "OWPML/Class/Para/cellSpan.h"
+#include "OWPML/Class/Para/tc.h"
+
+#include "OWPML/Class/Para/cellAddr.h"
+#include "OWPML/Class/Para/cellSpan.h"

--- a/src/sdk/SDK_Wrapper.cpp
+++ b/src/sdk/SDK_Wrapper.cpp
@@ -2,13 +2,6 @@
 #include "sdk/OwpmSDKPrelude.h"
 #include "sdk/SDK_Wrapper.h"
 
-// 세부 클래스 헤더 (스타일 파싱용)
-#include "OWPML/Class/Head/styles.h"
-#include "OWPML/Class/Head/StyleType.h"
-#include "OWPML/Class/Para/PType.h"
-#include "OWPML/Class/Para/t.h"
-#include "OWPML/Class/Para/text.h"
-
 namespace {
     std::map<unsigned int, std::wstring> g_styleMap;
 

--- a/src/walker/DocumentWalker.cpp
+++ b/src/walker/DocumentWalker.cpp
@@ -2,11 +2,11 @@
 #include "walker/WalkerConfig.h"
 #include "walker/WalkerDebug.h"
 #include "walker/TableRenderer.h"
+#include "sdk/OwpmSDKPrelude.h"
 
 #include <string>
 #include <iostream>
 
-#include "sdk/OwpmSDKPrelude.h"
 #include "sdk/SDK_Wrapper.h"
 #include "render/HtmlRenderer.h"
 

--- a/src/walker/TableRenderer.cpp
+++ b/src/walker/TableRenderer.cpp
@@ -13,10 +13,6 @@
 #include "sdk/SDK_Wrapper.h"
 #include "render/HtmlRenderer.h"
 
-#include "OWPML/Class/Para/cellAddr.h"
-#include "OWPML/Class/Para/cellSpan.h"
-#include "OWPML/Class/Para/tc.h"
-
 namespace
 {
     struct CellPos

--- a/src/walker/WalkerDebug.cpp
+++ b/src/walker/WalkerDebug.cpp
@@ -7,9 +7,6 @@
 #include "sdk/OwpmSDKPrelude.h"
 #include "sdk/SDK_Wrapper.h"
 
-#include "OWPML/Class/Para/cellAddr.h"
-#include "OWPML/Class/Para/cellSpan.h"
-
 namespace
 {
     std::map<unsigned int, int>& SeenIdOnce()


### PR DESCRIPTION
## 요약
* OWPML(한컴) SDK 헤더 include 경로를 OwpmSDKPrelude.h로 단일화했습니다.
* src/app/HwpxConverter.cpp 등 개별 cpp에서 직접 포함하던 OWPML 헤더를 제거했습니다.

## 변경이유
- 프로젝트 전반에서 OWPML 의존성을 한 파일(prelude)로 고정해 빌드/유지보수성을 올리기 위함입니다.
- 파일별로 OWPML 헤더가 흩어져 있으면 SDK 버전 변경/경로 변경 시 수정 범위가 커지고, include 충돌/순서 이슈가 발생하기 쉬워 정리했습니다.

## 노트

- 기능 동작은 동일합니다. (변환 결과/로직 변경 없음)
- include 정책만 변경되어 빌드 안정성 및 확장성 개선