### PR TITLE
feat: list rendering with <ol> dot style + robust CLI error messages

### DIFF
--- a/src/app/HwpxConverter.cpp
+++ b/src/app/HwpxConverter.cpp
@@ -7,8 +7,12 @@
 #include "walker/DocumentWalker.h"
 #include "sdk/SDK_Wrapper.h"
 
+#include <fstream>
+#include <string>
+#include <Windows.h>
 
-static bool WriteUtf8File(const std::wstring& path, const std::wstring& content) {
+static bool WriteUtf8File(const std::wstring& path, const std::wstring& content)
+{
     // wchar -> utf8
     int sizeNeeded = WideCharToMultiByte(
         CP_UTF8, 0,
@@ -38,24 +42,42 @@ bool ConvertHwpxToHtml(
     const std::wstring& inputPath,
     const std::wstring& outputPath,
     const ConvertOptions& opt
-) {
-    if (!opt.outputHtml) {
-        // 지금은 HTML만 지원
-        return false;
-    }
+)
+{
+    if (!opt.outputHtml) return false;
 
     // 1) 문서 열기
     OWPML::COwpmlDocumnet* doc = OWPML::COwpmlDocumnet::OpenDocument(inputPath.c_str());
     if (!doc) return false;
 
-    // 2) 스타일 맵 초기화 (head -> refList -> styles)
+    // 2) Head(refList) 초기화
     auto* head = doc->GetHead();
-    if (head) {
+    if (head)
+    {
         auto* refList = head->GetrefList();
-        if (refList) {
-            auto* styles = refList->Getstyles();
-            if (styles) {
+        if (refList)
+        {
+            // (1) styles
+            if (auto* styles = refList->Getstyles())
+            {
                 SDK::InitStyleMap(styles);
+            }
+
+            // (2) list meta
+            // 중요: numberings/bullets 먼저 -> paraProperties가 heading idRef를 보고 kind 추정
+            if (auto* numberings = refList->Getnumberings())
+            {
+                SDK::InitNumberings(numberings);
+            }
+
+            if (auto* bullets = refList->Getbullets())
+            {
+                SDK::InitBullets(bullets);
+            }
+
+            if (auto* paraProps = refList->GetparaProperties())
+            {
+                SDK::InitParaProperties(paraProps);
             }
         }
     }
@@ -63,28 +85,28 @@ bool ConvertHwpxToHtml(
     // 3) 변환 시작
     std::wstring out;
     auto* sections = doc->GetSections();
-    if (sections) {
-        for (auto* sec : *sections) {
+    if (sections)
+    {
+        for (auto* sec : *sections)
+        {
             ExtractText(sec, out);
         }
     }
 
-    //PARA 디버깅 코드
-    #if DEBUG_PARA_LOG
-
+#if DEBUG_PARA_LOG
     Html::DumpStyleLogToConsole();
+#endif
 
-    #endif // DEBUG_PARA_LOG
+    // 문서 끝에서 열려있을 수 있는 리스트 닫기
+    Html::FlushList(out);
 
-
-    // HTML 문서 래핑
+    // 4) HTML 문서 래핑
     std::wstring html;
-    Html::BeginHtmlDocument(html);   // 여기서 head + body 시작까지
-    html += out;                     // 본문(테이블/문단들)
-    Html::EndHtmlDocument(html);   // body/html 닫기
+    Html::BeginHtmlDocument(html);
+    html += out;
+    Html::EndHtmlDocument(html);
 
-
-    // 4) 저장
+    // 5) 저장
     const bool ok = WriteUtf8File(outputPath, html);
 
     delete doc;

--- a/src/app/HwpxConverter.cpp
+++ b/src/app/HwpxConverter.cpp
@@ -10,10 +10,48 @@
 #include <fstream>
 #include <string>
 #include <Windows.h>
+#include <algorithm>
+#include <cwctype>
+
+static std::wstring Trim(const std::wstring& s)
+{
+    size_t b = 0;
+    while (b < s.size() && iswspace(s[b])) b++;
+    size_t e = s.size();
+    while (e > b && iswspace(s[e - 1])) e--;
+    return s.substr(b, e - b);
+}
+
+static std::wstring StripQuotes(std::wstring s)
+{
+    s = Trim(s);
+    if (s.size() >= 2 && ((s.front() == L'"' && s.back() == L'"') || (s.front() == L'\'' && s.back() == L'\'')))
+        return s.substr(1, s.size() - 2);
+    return s;
+}
+
+static bool EndsWithCaseInsensitive(const std::wstring& s, const std::wstring& suffix)
+{
+    if (s.size() < suffix.size()) return false;
+
+    const size_t start = s.size() - suffix.size();
+    for (size_t i = 0; i < suffix.size(); ++i)
+    {
+        wchar_t a = towlower(s[start + i]);
+        wchar_t b = towlower(suffix[i]);
+        if (a != b) return false;
+    }
+    return true;
+}
+
+static bool IsHwpxPath(std::wstring path)
+{
+    path = StripQuotes(path);
+    return EndsWithCaseInsensitive(path, L".hwpx");
+}
 
 static bool WriteUtf8File(const std::wstring& path, const std::wstring& content)
 {
-    // wchar -> utf8
     int sizeNeeded = WideCharToMultiByte(
         CP_UTF8, 0,
         content.c_str(), (int)content.size(),
@@ -39,56 +77,52 @@ static bool WriteUtf8File(const std::wstring& path, const std::wstring& content)
 }
 
 bool ConvertHwpxToHtml(
-    const std::wstring& inputPath,
-    const std::wstring& outputPath,
+    const std::wstring& inputPathRaw,
+    const std::wstring& outputPathRaw,
     const ConvertOptions& opt
 )
 {
     if (!opt.outputHtml) return false;
 
-    // 1) 문서 열기
+    const std::wstring inputPath = StripQuotes(inputPathRaw);
+    const std::wstring outputPath = StripQuotes(outputPathRaw);
+
+    // 방어적 체크(엔트리 포인트가 main이 아니어도 안전)
+    if (!IsHwpxPath(inputPath)) return false;
+
     OWPML::COwpmlDocumnet* doc = OWPML::COwpmlDocumnet::OpenDocument(inputPath.c_str());
     if (!doc) return false;
 
-    // 2) Head(refList) 초기화
+    // ===== Head(refList) 초기화 =====
     auto* head = doc->GetHead();
-    if (head)
-    {
+    if (head) {
         auto* refList = head->GetrefList();
-        if (refList)
-        {
-            // (1) styles
-            if (auto* styles = refList->Getstyles())
-            {
+        if (refList) {
+            // 1) 스타일
+            if (auto* styles = refList->Getstyles()) {
                 SDK::InitStyleMap(styles);
             }
 
-            // (2) list meta
-            // 중요: numberings/bullets 먼저 -> paraProperties가 heading idRef를 보고 kind 추정
-            if (auto* numberings = refList->Getnumberings())
-            {
+            // 2) 리스트 관련
+            if (auto* numberings = refList->Getnumberings()) {
                 SDK::InitNumberings(numberings);
             }
 
-            if (auto* bullets = refList->Getbullets())
-            {
+            if (auto* bullets = refList->Getbullets()) {
                 SDK::InitBullets(bullets);
             }
 
-            if (auto* paraProps = refList->GetparaProperties())
-            {
+            if (auto* paraProps = refList->GetparaProperties()) {
                 SDK::InitParaProperties(paraProps);
             }
         }
     }
 
-    // 3) 변환 시작
+    // ===== 변환 시작 =====
     std::wstring out;
     auto* sections = doc->GetSections();
-    if (sections)
-    {
-        for (auto* sec : *sections)
-        {
+    if (sections) {
+        for (auto* sec : *sections) {
             ExtractText(sec, out);
         }
     }
@@ -97,16 +131,13 @@ bool ConvertHwpxToHtml(
     Html::DumpStyleLogToConsole();
 #endif
 
-    // 문서 끝에서 열려있을 수 있는 리스트 닫기
     Html::FlushList(out);
 
-    // 4) HTML 문서 래핑
     std::wstring html;
     Html::BeginHtmlDocument(html);
     html += out;
     Html::EndHtmlDocument(html);
 
-    // 5) 저장
     const bool ok = WriteUtf8File(outputPath, html);
 
     delete doc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,33 @@
+// main.cpp
 #include <iostream>
 #include <string>
 #include <cwctype>
+#include <algorithm>
+#include <filesystem>
 
 #include <fcntl.h>
 #include <io.h>
 
 #include "app/HwpxConverter.h"
+
+namespace fs = std::filesystem;
+
+static std::wstring Trim(const std::wstring& s)
+{
+    size_t b = 0;
+    while (b < s.size() && iswspace(s[b])) b++;
+    size_t e = s.size();
+    while (e > b && iswspace(s[e - 1])) e--;
+    return s.substr(b, e - b);
+}
+
+static std::wstring StripQuotes(std::wstring s)
+{
+    s = Trim(s);
+    if (s.size() >= 2 && ((s.front() == L'"' && s.back() == L'"') || (s.front() == L'\'' && s.back() == L'\'')))
+        return s.substr(1, s.size() - 2);
+    return s;
+}
 
 static bool EndsWithIgnoreCase(const std::wstring& s, const std::wstring& suffix)
 {
@@ -19,37 +41,198 @@ static bool EndsWithIgnoreCase(const std::wstring& s, const std::wstring& suffix
     return true;
 }
 
+static bool IsHwpxPath(const std::wstring& path)
+{
+    return EndsWithIgnoreCase(path, L".hwpx");
+}
+
+static bool ContainsWhitespaceOrParen(const std::wstring& s)
+{
+    for (wchar_t ch : s) {
+        if (iswspace(ch) || ch == L'(' || ch == L')') return true;
+    }
+    return false;
+}
+
+// Windows 파일명에서 금지 문자 제거(출력 "파일명"만 정리)
+static std::wstring SanitizeFileName(std::wstring name)
+{
+    // 금지 문자: < > : " / \ | ? *  + 제어문자(0~31)
+    for (auto& ch : name)
+    {
+        if (ch < 32) { ch = L'_'; continue; }
+        switch (ch)
+        {
+        case L'<': case L'>': case L':': case L'"':
+        case L'/': case L'\\': case L'|': case L'?': case L'*':
+            ch = L'_';
+            break;
+        default:
+            break;
+        }
+    }
+
+    // 끝의 공백/점 제거 (Windows 규칙)
+    while (!name.empty() && (name.back() == L' ' || name.back() == L'.'))
+        name.pop_back();
+
+    name = Trim(name);
+    if (name.empty()) name = L"output";
+
+    // 예약 장치명(CON, PRN, AUX, NUL, COM1~9, LPT1~9) 방어
+    auto upper = name;
+    std::transform(upper.begin(), upper.end(), upper.begin(), [](wchar_t c) { return (wchar_t)towupper(c); });
+
+    auto IsReserved = [&](const std::wstring& u) -> bool {
+        if (u == L"CON" || u == L"PRN" || u == L"AUX" || u == L"NUL") return true;
+        if (u.rfind(L"COM", 0) == 0 && u.size() == 4 && (u[3] >= L'1' && u[3] <= L'9')) return true;
+        if (u.rfind(L"LPT", 0) == 0 && u.size() == 4 && (u[3] >= L'1' && u[3] <= L'9')) return true;
+        return false;
+        };
+
+    if (IsReserved(upper))
+        name = L"_" + name;
+
+    return name;
+}
+
+static fs::path MakeUniquePath(const fs::path& desired)
+{
+    if (!fs::exists(desired)) return desired;
+
+    fs::path dir = desired.parent_path();
+    std::wstring stem = desired.stem().wstring();
+    std::wstring ext = desired.extension().wstring();
+    if (ext.empty()) ext = L".html";
+
+    for (int i = 1; i < 10000; ++i)
+    {
+        std::wstring candidateName = stem + L" (" + std::to_wstring(i) + L")" + ext;
+        fs::path cand = dir.empty() ? fs::path(candidateName) : (dir / candidateName);
+        if (!fs::exists(cand)) return cand;
+    }
+    // 비정상적으로 많이 겹치면 마지막 fallback
+    return desired;
+}
+
+// 출력 경로에서 "파일명만" 정리하고, 확장자 .html 보장
+static fs::path NormalizeOutputPath(const fs::path& outRaw)
+{
+    fs::path dir = outRaw.parent_path();
+    std::wstring filename = outRaw.filename().wstring();
+
+    if (filename.empty()) filename = L"output.html";
+
+    // 확장자 처리
+    fs::path tmp(filename);
+    std::wstring stem = tmp.stem().wstring();
+    std::wstring ext = tmp.extension().wstring();
+
+    if (!EndsWithIgnoreCase(ext, L".html")) {
+        // 사용자가 .htm / 다른 확장자 / 확장자 없음 -> .html로 고정
+        ext = L".html";
+    }
+
+    stem = SanitizeFileName(stem);
+    fs::path finalName = fs::path(stem + ext);
+
+    if (dir.empty()) return finalName;
+    return dir / finalName;
+}
+
+static void PrintUsage(const wchar_t* argv0)
+{
+    std::wcout << L"사용법:\n"
+        << L"  " << argv0 << L" <input.hwpx> [output.html]\n\n"
+        << L"규칙:\n"
+        << L"  - output 생략 시: input과 같은 폴더에 <입력파일명>.html 자동 생성\n"
+        << L"  - 출력 파일명만 안전 문자로 정리(입력 파일명은 변경하지 않음)\n"
+        << L"  - 동일 파일 존재 시: (1), (2)... 붙여서 덮어쓰기 방지\n";
+}
+
 int wmain(int argc, wchar_t* argv[])
 {
     // 콘솔 wide 출력 안정화 (한글/경로 깨짐 방지)
     _setmode(_fileno(stdout), _O_U16TEXT);
     _setmode(_fileno(stderr), _O_U16TEXT);
 
-    if (argc < 3) {
-        std::wcout << L"사용법: " << argv[0] << L" <input.hwpx> <output.html>\n";
+    if (argc < 2) {
+        PrintUsage(argv[0]);
         return -1;
     }
 
-    const std::wstring inputPath = argv[1];
-    const std::wstring outputPath = argv[2];
+    // 공백 경로를 따옴표로 안 감싸면 argv가 쪼개져 argc가 커짐
+    // 이번 버전은 옵션 파싱 없이 "2개 또는 3개 인자"만 지원
+    if (argc > 3) {
+        std::wcout << L"[ERROR] 인자 개수가 너무 많습니다. 입력 경로에 공백이 있으면 따옴표로 감싸주세요.\n";
+        std::wcout << L"예) " << argv[0] << L" \"C:\\path with space\\in.hwpx\" out.html\n\n";
+        PrintUsage(argv[0]);
+        return -1;
+    }
+
+    const std::wstring inputRaw = argv[1];
+    const std::wstring inputPathW = StripQuotes(inputRaw);
+    const fs::path inputPath(inputPathW);
 
     // 1) 확장자 검사
-    if (!EndsWithIgnoreCase(inputPath, L".hwpx")) {
-        std::wcout << L"[ERROR] 입력 파일은 .hwpx만 지원합니다.\n"
-            << std::flush;
+    if (!IsHwpxPath(inputPathW)) {
+        std::wcout << L"[ERROR] 입력 파일은 .hwpx만 지원합니다.\n";
+        std::wcout << L"        입력: " << inputPathW << L"\n";
         return -1;
     }
+
+    // 2) 입력 파일 존재 검사
+    std::error_code ec;
+    if (!fs::exists(inputPath, ec)) {
+        std::wcout << L"[ERROR] 입력 파일을 찾을 수 없습니다.\n";
+        std::wcout << L"        입력: " << inputPathW << L"\n";
+        if (ContainsWhitespaceOrParen(inputPathW)) {
+            std::wcout << L"        힌트: 경로에 공백/괄호가 있으면 따옴표로 감싸서 실행해 주세요.\n";
+        }
+        return -1;
+    }
+
+    // 3) 출력 경로 결정(옵션)
+    fs::path outputPath;
+    if (argc == 3)
+    {
+        const std::wstring outRaw = StripQuotes(argv[2]);
+        fs::path outPathRaw(outRaw);
+
+        // 파일명만 sanitize + .html 보장
+        outputPath = NormalizeOutputPath(outPathRaw);
+
+        // 출력 디렉토리 존재 검사(명시된 경우)
+        fs::path outDir = outputPath.parent_path();
+        if (!outDir.empty() && !fs::exists(outDir, ec)) {
+            std::wcout << L"[ERROR] 출력 폴더가 존재하지 않습니다.\n";
+            std::wcout << L"        출력: " << outputPath.wstring() << L"\n";
+            return -1;
+        }
+    }
+    else
+    {
+        // 자동 생성: 입력과 같은 폴더 + <입력 stem>.html
+        fs::path dir = inputPath.parent_path();
+        std::wstring stem = inputPath.stem().wstring();
+        stem = SanitizeFileName(stem);
+
+        outputPath = dir / fs::path(stem + L".html");
+    }
+
+    // 4) 덮어쓰기 방지: (1)(2)...
+    outputPath = MakeUniquePath(outputPath);
 
     ConvertOptions opt;
     opt.outputHtml = true;
 
-    // 2) 변환 시도
-    if (!ConvertHwpxToHtml(inputPath, outputPath, opt)) {
-        std::wcout << L"[ERROR] 변환 실패: 표준 HWPX 파일이 아니거나 손상된 파일일 수 있습니다.\n"
-            << std::flush;
+    // 5) 변환
+    if (!ConvertHwpxToHtml(inputPathW, outputPath.wstring(), opt)) {
+        std::wcout << L"[ERROR] 변환 실패: 표준 HWPX 파일이 아니거나 손상된 파일일 수 있습니다.\n";
+        std::wcout << L"        입력: " << inputPathW << L"\n";
         return -1;
     }
 
-    std::wcout << L"변환 완료: " << outputPath << L"\n";
+    std::wcout << L"변환 완료: " << outputPath.wstring() << L"\n";
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,21 +1,55 @@
 #include <iostream>
+#include <string>
+#include <cwctype>
+
+#include <fcntl.h>
+#include <io.h>
+
 #include "app/HwpxConverter.h"
+
+static bool EndsWithIgnoreCase(const std::wstring& s, const std::wstring& suffix)
+{
+    if (s.size() < suffix.size()) return false;
+    size_t off = s.size() - suffix.size();
+    for (size_t i = 0; i < suffix.size(); ++i) {
+        wchar_t a = towlower(s[off + i]);
+        wchar_t b = towlower(suffix[i]);
+        if (a != b) return false;
+    }
+    return true;
+}
 
 int wmain(int argc, wchar_t* argv[])
 {
+    // 콘솔 wide 출력 안정화 (한글/경로 깨짐 방지)
+    _setmode(_fileno(stdout), _O_U16TEXT);
+    _setmode(_fileno(stderr), _O_U16TEXT);
+
     if (argc < 3) {
         std::wcout << L"사용법: " << argv[0] << L" <input.hwpx> <output.html>\n";
+        return -1;
+    }
+
+    const std::wstring inputPath = argv[1];
+    const std::wstring outputPath = argv[2];
+
+    // 1) 확장자 검사
+    if (!EndsWithIgnoreCase(inputPath, L".hwpx")) {
+        std::wcout << L"[ERROR] 입력 파일은 .hwpx만 지원합니다.\n"
+            << std::flush;
         return -1;
     }
 
     ConvertOptions opt;
     opt.outputHtml = true;
 
-    if (!ConvertHwpxToHtml(argv[1], argv[2], opt)) {
-        std::wcout << L"변환 실패\n";
+    // 2) 변환 시도
+    if (!ConvertHwpxToHtml(inputPath, outputPath, opt)) {
+        std::wcout << L"[ERROR] 변환 실패: 표준 HWPX 파일이 아니거나 손상된 파일일 수 있습니다.\n"
+            << std::flush;
         return -1;
     }
 
-    std::wcout << L"변환 완료: " << argv[2] << L"\n";
+    std::wcout << L"변환 완료: " << outputPath << L"\n";
     return 0;
 }

--- a/src/render/HtmlRenderer.h
+++ b/src/render/HtmlRenderer.h
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace OWPML {
     class CPType;
     class CT;
+}
+
+namespace SDK {
+    struct ListInfo;
+    enum class ListKind : std::uint8_t;
 }
 
 namespace Html {
@@ -14,17 +20,23 @@ namespace Html {
     // ===========================
     enum class CellBreakMode
     {
-        Space,    // " "
-        Newline,  // "\n"
-        BrTag     // "<br/>"
+        Space,
+        Newline,
+        BrTag
     };
 
-    // CellMode ฐüทร
     void SetCellMode(bool on);
     bool IsCellMode();
 
     void SetCellBreakMode(CellBreakMode mode);
     void SetCellParagraphMode(CellBreakMode mode);
+
+    // ===========================
+    // List state machine
+    // ===========================
+    void EnsureListOpen(std::wstring& out, const SDK::ListInfo& info);
+    void FlushList(std::wstring& out);
+    void BeginListItemMode(const SDK::ListInfo& info);
 
     // Paragraph lifecycle
     void BeginParagraph(OWPML::CPType* para);

--- a/src/sdk/SDK_Wrapper.cpp
+++ b/src/sdk/SDK_Wrapper.cpp
@@ -1,11 +1,17 @@
 #include <cwctype>
+#include <map>
+#include <string>
+#include <cstdint>
+
 #include "sdk/OwpmSDKPrelude.h"
 #include "sdk/SDK_Wrapper.h"
 
 namespace {
+    // =========================
+    // Style map
+    // =========================
     std::map<unsigned int, std::wstring> g_styleMap;
 
-    // 앞/뒤 공백 제거
     static std::wstring Trim(const std::wstring& s)
     {
         size_t start = 0;
@@ -17,21 +23,15 @@ namespace {
         return s.substr(start, end - start);
     }
 
-    // "Normal Copy6" 같은 복제 스타일 흡수
     static std::wstring NormalizeStyleEngName(std::wstring eng)
     {
         eng = Trim(eng);
-
-        // engName이 비어있으면 Normal로 fallback
         if (eng.empty()) return L"Normal";
 
-        // 규칙: " Copy" + 숫자로 끝나면 Copy 부분 제거
-        // 예: "Normal Copy6" -> "Normal"
         const std::wstring marker = L" Copy";
         size_t pos = eng.rfind(marker);
         if (pos != std::wstring::npos)
         {
-            // marker 뒤쪽이 숫자로만 구성되면 Copy suffix로 판단
             size_t numStart = pos + marker.size();
             if (numStart < eng.size())
             {
@@ -43,7 +43,7 @@ namespace {
 
                 if (allDigits)
                 {
-                    eng = Trim(eng.substr(0, pos)); // " CopyN" 제거
+                    eng = Trim(eng.substr(0, pos));
                     if (eng.empty()) return L"Normal";
                 }
             }
@@ -51,10 +51,34 @@ namespace {
 
         return eng;
     }
+
+    // =========================
+    // List maps
+    // =========================
+    struct ParaPrListMeta {
+        SDK::ListKind kind = SDK::ListKind::None;
+        std::uint32_t idRef = 0;
+        std::uint32_t level = 0;
+    };
+
+    std::map<std::uint32_t, ParaPrListMeta> g_paraPrListMeta;
+
+    struct BulletMeta {
+        std::wstring ch;
+        std::wstring checkedCh;
+        bool checkable = false;
+    };
+    std::map<std::uint32_t, BulletMeta> g_bulletMetaById;
+
+    // numbering은 존재 여부만
+    std::map<std::uint32_t, bool> g_numberingExistsById;
 }
 
 namespace SDK {
 
+    // =========================
+    // Style
+    // =========================
     void InitStyleMap(OWPML::CStyles* pStyles) {
         if (!pStyles) return;
         g_styleMap.clear();
@@ -64,9 +88,8 @@ namespace SDK {
             auto* pStyle = pStyles->Getstyle((int)i);
             if (!pStyle) continue;
 
-            std::wstring raw = pStyle->GetEngName();              // 원본 engName
-            std::wstring norm = NormalizeStyleEngName(raw);       // 정규화 engName
-
+            std::wstring raw = pStyle->GetEngName();
+            std::wstring norm = NormalizeStyleEngName(raw);
             g_styleMap[pStyle->GetId()] = norm;
         }
     }
@@ -77,6 +100,9 @@ namespace SDK {
         return L"Body";
     }
 
+    // =========================
+    // Tree helpers
+    // =========================
     unsigned int GetID(OWPML::CObject* obj) {
         return obj ? obj->GetID() : 0;
     }
@@ -99,6 +125,9 @@ namespace SDK {
         return *it;
     }
 
+    // =========================
+    // Paragraph / Text
+    // =========================
     unsigned int GetParaStyleID(OWPML::CPType* para) {
         return para ? para->GetStyleIDRef() : 0;
     }
@@ -113,6 +142,137 @@ namespace SDK {
 
     std::wstring GetCharValue(OWPML::CChar* ch) {
         return ch ? ch->Getval() : L"";
+    }
+
+    unsigned int GetParaPrIDRef(OWPML::CPType* para)
+    {
+        if (!para) return 0;
+        return (unsigned int)para->GetParaPrIDRef();
+    }
+
+    // ============================================================
+    // LIST INIT
+    // ============================================================
+
+    void InitNumberings(OWPML::CNumberings* numberings)
+    {
+        g_numberingExistsById.clear();
+        if (!numberings) return;
+
+        const unsigned int count = numberings->GetItemCnt();
+        for (unsigned int i = 0; i < count; ++i)
+        {
+            auto* n = numberings->Getnumbering((int)i);
+            if (!n) continue;
+            g_numberingExistsById[(std::uint32_t)n->GetId()] = true;
+        }
+    }
+
+    void InitBullets(OWPML::CBullets* bullets)
+    {
+        g_bulletMetaById.clear();
+        if (!bullets) return;
+
+        const unsigned int count = bullets->GetItemCnt();
+        for (unsigned int i = 0; i < count; ++i)
+        {
+            auto* b = bullets->Getbullet((int)i);
+            if (!b) continue;
+
+            BulletMeta meta;
+            meta.ch = b->GetChar() ? b->GetChar() : L"";
+            meta.checkedCh = b->GetCheckedChar() ? b->GetCheckedChar() : L"";
+
+            // checkable은 paraHead에 있음
+            auto* ph = b->GetparaHead(0);
+            if (ph)
+            {
+                // GetCheckable()이 int/UINT 형태일 확률 큼
+                meta.checkable = (ph->GetCheckable() != 0);
+            }
+
+            g_bulletMetaById[(std::uint32_t)b->GetId()] = meta;
+        }
+    }
+
+    void InitParaProperties(OWPML::CParaProperties* paraProps)
+    {
+        g_paraPrListMeta.clear();
+        if (!paraProps) return;
+
+        const unsigned int count = paraProps->GetItemCnt();
+
+        for (unsigned int i = 0; i < count; ++i)
+        {
+            auto* paraPr = paraProps->GetparaPr((int)i);
+            if (!paraPr) continue;
+
+            const std::uint32_t paraPrId = (std::uint32_t)paraPr->GetId();
+            ParaPrListMeta meta;
+
+            auto* heading = paraPr->Getheading();
+            if (heading)
+            {
+                const std::uint32_t idRef = (std::uint32_t)heading->GetIdRef();
+                const std::uint32_t level = (std::uint32_t)heading->GetLevel();
+
+                // ★ 핵심: idRef가 0이면 "리스트 아님"
+                if (idRef != 0)
+                {
+                    const bool isNumbering = (g_numberingExistsById.find(idRef) != g_numberingExistsById.end());
+                    const bool isBullet = (g_bulletMetaById.find(idRef) != g_bulletMetaById.end());
+
+                    // ★ 핵심: 실제 bullets/numberings 중 하나에 존재할 때만 리스트 인정
+                    if (isNumbering || isBullet)
+                    {
+                        meta.kind = isNumbering ? ListKind::Numbering : ListKind::Bullet;
+                        meta.idRef = idRef;
+                        meta.level = level;
+                    }
+                }
+            }
+
+            g_paraPrListMeta[paraPrId] = meta;
+        }
+    }
+
+    // ============================================================
+    // LIST INFO EXTRACT
+    // ============================================================
+    ListInfo GetListInfoFromParagraph(OWPML::CPType* para)
+    {
+        ListInfo info;
+        if (!para) return info;
+
+        const std::uint32_t paraPrId = (std::uint32_t)GetParaPrIDRef(para);
+        if (paraPrId == 0) return info;
+
+        auto it = g_paraPrListMeta.find(paraPrId);
+        if (it == g_paraPrListMeta.end()) return info;
+
+        const ParaPrListMeta& meta = it->second;
+
+        // meta가 None이면 그대로 리턴
+        if (meta.kind == ListKind::None) return info;
+
+        // ★ 안전장치: idRef==0이면 리스트로 치지 않음
+        if (meta.idRef == 0) return info;
+
+        info.kind = meta.kind;
+        info.idRef = meta.idRef;
+        info.level = meta.level;
+
+        if (info.kind == ListKind::Bullet)
+        {
+            auto bit = g_bulletMetaById.find(info.idRef);
+            if (bit != g_bulletMetaById.end())
+            {
+                info.bulletChar = bit->second.ch;
+                info.checkable = bit->second.checkable;
+            }
+        }
+
+        return info;
     }
 
 } // namespace SDK

--- a/src/sdk/SDK_Wrapper.h
+++ b/src/sdk/SDK_Wrapper.h
@@ -1,13 +1,20 @@
 #pragma once
 #include <string>
+#include <cstdint>
 
 namespace OWPML {
     class CObject;
+
     class CStyles;
-    class CStyleType;
     class CPType;
     class CT;
     class CChar;
+
+    // Head쪽 타입들
+    class CRefList;
+    class CParaProperties;
+    class CBullets;
+    class CNumberings;
 }
 
 namespace SDK {
@@ -31,4 +38,42 @@ namespace SDK {
 
     // ===== 글자 =====
     std::wstring GetCharValue(OWPML::CChar* ch);
-}
+
+    // ===== paraPrIDRef =====
+    unsigned int GetParaPrIDRef(OWPML::CPType* para);
+
+    // ============================================================
+    // LIST INFO
+    // ============================================================
+
+    enum class ListKind : std::uint8_t {
+        None = 0,
+        Numbering = 1,
+        Bullet = 2
+    };
+
+    struct ListInfo {
+        ListKind kind = ListKind::None;
+
+        // heading이 가리키는 idRef (numbering id 또는 bullet id)
+        std::uint32_t idRef = 0;
+
+        // 문서의 level (정보만 보존)
+        std::uint32_t level = 0;
+
+        // bullet일 때 원본 글머리 문자 (렌더링은 점으로 통일하더라도 보존)
+        std::wstring bulletChar;
+
+        // 체크형(checkbox) 여부 (정책상 렌더링은 점으로 통일)
+        bool checkable = false;
+    };
+
+    // Head에서 paraPr/numberings/bullets 맵 구성
+    void InitParaProperties(OWPML::CParaProperties* paraProps);
+    void InitBullets(OWPML::CBullets* bullets);
+    void InitNumberings(OWPML::CNumberings* numberings);
+
+    // 문단이 리스트인지 판별 + bullet char 추출
+    ListInfo GetListInfoFromParagraph(OWPML::CPType* para);
+
+} // namespace SDK

--- a/src/walker/WalkerConfig.h
+++ b/src/walker/WalkerConfig.h
@@ -58,4 +58,15 @@ namespace WalkerConfig
     inline constexpr bool IsRowGroup(std::uint32_t id) { return id == ROW_GROUP_ID; }
     inline constexpr bool IsCellWrapper(std::uint32_t id) { return id == CELL_WRAPPER_ID; }
 
+    // =========================================================
+    // LIST PARA DUMP 
+    // =========================================================
+    inline constexpr bool DUMP_LIST_PARA_SUBTREE = false;   // 리스트 문단만 subtree 덤프
+    inline constexpr int  DUMP_LIST_PARA_LIMIT = 50;       // 최대 N개 문단만
+    inline constexpr int  DUMP_LIST_MAX_NODES = 400;       // dump safe 노드 제한
+
+    // paraPrIDRef로 필터링 (너 xml에서 paraPrIDRef="20")
+    inline constexpr bool DUMP_LIST_FILTER_BY_PARAPR = true;
+    inline constexpr std::uint32_t LIST_PARA_PR_ID = 20;
+
 } // namespace WalkerConfig

--- a/src/walker/WalkerDebug.h
+++ b/src/walker/WalkerDebug.h
@@ -16,4 +16,7 @@ namespace WalkerDebug
 
     // 덤프: cellWrapper 내부 child ID들 출력 + cellAddr/span 확인
     void DumpCellWrapperChildren(OWPML::CObject* cellWrapper, int r, int c, int depth);
+
+    void DumpSubtreeSafe(OWPML::CObject* root, int absDepth, int maxNodes);
+
 }


### PR DESCRIPTION
## 설명
이번 PR은 “리스트 번호 계산을 하지 않는다”는 정책을 고정한 상태에서, HWPX의 bullet/numbering을 모두 <ol>로 렌더링하되 화면에는 ul처럼 점만 보이도록 처리했습니다. 또한 입력 확장자 검증 및 표준 HWPX가 아닌 파일에 대한 에러 메시지 출력, Windows 콘솔에서 한글 경로 출력 안정화까지 포함합니다.

## 변경 사항
1. 리스트 렌더링(번호 계산 X)
* HWPX의 bullet/numbering을 <ol class="hwpx-ol-dot">로 통일 렌더링
* CSS로 list-style-type: disc 적용하여 숫자 대신 점만 표시
* 번호/계층 번호 계산은 하지 않음(문서와 달라질 위험 제거)
* 문서/구간 경계에서 FlushList로 열린 리스트를 안정적으로 닫도록 처리

2. SDK 기반 리스트 메타 추출(룰베이스)
* paraPrIDRef를 기반으로 head(refList)의 paraProperties/heading을 조회해 “리스트 여부” 판정
* bullet인 경우 idRef 기반으로 bullets 메타(글머리표 타입) 연동 가능하도록 구성
* 체크형 글머리표(checkable)는 정책상 일반 점으로 통일(추후 확장 여지 남김)

3. CLI/입력 검증 및 에러 메시지 개선
* 입력 확장자 .hwpx만 지원: 아니면 즉시 명확한 에러 출력
* .hwpx인데 SDK OpenDocument 실패 시: “표준 HWPX가 아니거나 손상” 안내
* Windows 콘솔 wide 출력 모드 설정으로 한글 경로/메시지 깨짐 방지
* 인자에 따옴표가 들어오는 케이스 방어(StripQuotes)

## 테스트
* list.hwpx(번호/글머리표/체크형 포함)에서 <ol> 생성 및 점 표시 확인
* 공공기관 문서 다수에서:
  * 정상 HWPX 변환 성공 확인
  * 확장자 .hwp 입력 시 즉시 “[ERROR] 입력 파일은 .hwpx만 지원합니다.” 출력 확인
  * “hwpx처럼 보이지만 zip 구조가 아닌 비표준 파일”에서 OpenDocument 실패 시 에러 메시지 확인

## 주의/정책
* 본 PR은 “번호 계산을 하지 않는다”를 강제합니다.
* 따라서 numbering도 ol로만 열고, 점 표시만 합니다(문서 원본 번호와의 불일치 방지).
* 향후 정확한 numbering 재현이 필요하면, 별도 옵션/모듈로 분리해서 추가하는 방향을 권장합니다.

## 관련 이슈
* “HWPX로 보이지만 열리지 않는 파일 처리”
* “입력/출력 파일명 안전 처리 및 자동 생성 규칙”

* 리스트 판정(paraPrIDRef -> heading/idRef) 로직의 안전성/오탐 가능성
* 테이블/셀 경계에서 리스트 flush 타이밍 적절성
* CLI 에러 메시지/사용성(한글 경로, 따옴표, 출력 파일명 정책 확장 가능성)